### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    target-branch: "default"
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: '*'
+        update-types: # Prevent Cargo.toml patch updates
+          - version-update:semver-patch
+    target-branch: "default"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
       - name: Git commit info
         run: git log -n 1
 
-      - uses: actions/setup-python@master
+      - name: Install Python ${{ matrix.python }}
+        uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install Rust
-        run: rustup install --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
 
       - name: Build
         run: cargo build --verbose
@@ -46,16 +49,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup install --no-self-update stable && rustup default stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: "rustfmt, clippy"
 
       - name: Check formatting
         run: |
-          rustup component add rustfmt
           cargo fmt -- --check
 
       - name: Lint with Clippy
         run: |
-          rustup component add clippy
           cargo clippy -- -D warnings
 
   #-----------------------------------------------------------------------------
@@ -120,8 +123,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        run: rustup install --no-self-update stable && rustup default stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Publish
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ pest_derive = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5.17", features = ["derive"] }
-ureq = "2.10.1"
-crossterm = "0.28.1"
-tempfile = "=3.11.0" # lock to align windows-sys requirements
+ureq = "3.0.11"
+crossterm = "0.29.0"
+tempfile = "3.11.0"
 toml = "0.8.19"
 sha2 = "0.10.8"
-serde_yaml = "0.9.34"
+serde_yaml = "0.9.34" # deprecated
 
 [profile.release]
 debug = false

--- a/doc/articles/performance/validate_native.py
+++ b/doc/articles/performance/validate_native.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
 # user    0m0.254s
 # sys     0m0.040s
 
-# unlike pip-audit, fetter searches all installed packages, not just what is in requirmeents.
+# unlike pip-audit, fetter searches all installed packages, not just what is in requirements.
 # takes 14% time for osv, or 7.14 times faster
 
 # {.env311-fetter-bench}{default} % time pip-audit -s osv
@@ -183,4 +183,3 @@ if __name__ == '__main__':
 # real    0m6.817s
 # user    0m0.106s
 # sys     0m0.100s
-

--- a/src/ureq_client.rs
+++ b/src/ureq_client.rs
@@ -12,14 +12,14 @@ pub struct UreqClientLive;
 
 impl UreqClient for UreqClientLive {
     fn post(&self, url: &str, body: &str) -> Result<String, ureq::Error> {
-        let response = ureq::post(url)
-            .set("Content-Type", "application/json")
-            .send_string(body)?;
-        Ok(response.into_string()?)
+        let mut response = ureq::post(url)
+            .header("Content-Type", "application/json")
+            .send(body)?;
+        Ok(response.body_mut().read_to_string()?)
     }
     fn get(&self, url: &str) -> Result<String, ureq::Error> {
-        let response = ureq::get(url).call()?;
-        Ok(response.into_string()?)
+        let mut response = ureq::get(url).call()?;
+        Ok(response.body_mut().read_to_string()?)
     }
 }
 

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,4 @@
+scan:
+  skip-files:
+    - "doc/articles/**/requirements.txt" # examples are outdated and vulnerable on purpose
+    # Trivy doesn't know requirements.uv.lock files


### PR DESCRIPTION
### Updates
- Update dependencies (ureq 3 was breaking)
- Let Dependabot update Cargo and GitHub Actions

### Improvements
- Ignore outdated and vulnerable doc/articles requirements.txt in trivy
- Use setup-rust-toolchain including caching in CI