### PR TITLE
chore(ci): scan build vulnerabilities with trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,25 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+      - name: Build auditable
+        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.python == '3.13'
+        run: | # https://github.com/rust-secure-code/cargo-auditable#usage
+          cargo install cargo-auditable cargo-audit
+          cargo auditable build
+
+      - name: Fail auditable build on high/critical vulnerabilities
+        if: matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' && matrix.python == '3.13'
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: rootfs # https://trivy.dev/latest/docs/coverage/language/rust/#binaries
+          format: table
+          scan-ref: target/debug/fetter
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          ignore-unfixed: true
+          exit-code: 1
+          trivy-config: trivy.yaml
+
   #-----------------------------------------------------------------------------
   quality:
     name: Quality
@@ -73,7 +92,7 @@ jobs:
       - name: Generate Trivy vulnerability report
         uses: aquasecurity/trivy-action@master
         with:
-          scan-type: "fs"
+          scan-type: fs
           output: trivy-report.json
           format: json
           scan-ref: .
@@ -90,7 +109,7 @@ jobs:
       - name: Fail build on high/critical vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
-          scan-type: "fs"
+          scan-type: fs
           format: table
           scan-ref: .
           severity: HIGH,CRITICAL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,45 @@ jobs:
           cargo clippy -- -D warnings
 
   #-----------------------------------------------------------------------------
+  security:
+    name: Security Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#skipping-setup-when-calling-trivy-action-multiple-times
+      # The first call to the action will invoke setup-trivy and install trivy
+      - name: Generate Trivy vulnerability report
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          output: trivy-report.json
+          format: json
+          scan-ref: .
+          exit-code: 0
+          trivy-config: trivy.yaml
+
+      - name: Upload vulnerability report
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: trivy-report.json
+          retention-days: 30
+
+      - name: Fail build on high/critical vulnerabilities
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "fs"
+          format: table
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 1
+          # On a subsequent call trivy is already installed so we can skip setup
+          skip-setup-trivy: true
+          trivy-config: trivy.yaml
+
+  #-----------------------------------------------------------------------------
 #   coverage:
 #     name: Coverage
 #     runs-on: ubuntu-latest


### PR DESCRIPTION
### CI
- Scan build vulnerabilities with trivy
- trivy-report.json is available in builds for 30 days
- High and critical vulnerabilities let the build fail
- Ancient doc/articles/**/requirements.txt are ignored in trivy.yaml config